### PR TITLE
ER図の追加とREADME更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Webページにアクセス
 ## 使用する技術スタック
 - フレームワーク：Ruby on Rails 7.x（Hotwire / Stimulus）
 - 言語：Ruby 3.x
-- DB：MVPは不要（必要であればPostgreSQL）
+- DB：MVPは不要（YAMLで開始）／将来的に PostgreSQL で `languages`・`messages` を導入予定
 - デプロイ：Render / Fly.io（無料枠想定）
 - CSS：Tailwind CSS
 - テスト：RSpec（最低限のSystemテスト）
@@ -69,3 +69,7 @@ Webページにアクセス
 
 ## 画面遷移図
 Figma：https://www.figma.com/design/M8rHbwDhZ4WLX1cp5a8F7k/%E5%8D%92%E6%A5%AD%E5%88%B6%E4%BD%9CDaijoubu-Button?node-id=0-1&t=amO3nu7fyYYCDAMr-1
+
+## ER図
+- https://gyazo.com/966b235b5074d3e8bf4ef586f1cabe9d
+- 目的：MVP後の拡張を見据えた最小スキーマ（`languages` 1 — n `messages`）


### PR DESCRIPTION
本PRではER図を作成し、READMEへリンク追記しました。
下記ご確認をお願いします。 

## ER図（スクリーンショット） 
[![Image from Gyazo](https://i.gyazo.com/966b235b5074d3e8bf4ef586f1cabe9d.png)](https://gyazo.com/966b235b5074d3e8bf4ef586f1cabe9d) 

## 本サービスの概要（～700字） 
ボタンを押すだけで多言語の「大丈夫（It’s OK / It’s gonna be fine）」を表示する、即効性重視のWebアプリです。不安時にワンクリックで前向きな一言を得られます。MVPでは「表示」「切替」「コピー」に絞り、ログイン不要で誰でも利用可能な形でリリースします。開発負荷を抑えつつ確実に完成させ、追い込み時期の不安や焦りに寄り添う体験を届けます。 将来、言語の追加や表示ON/OFF、並び順制御などの拡張を見据え、ER図は languages（言語マスタ）と messages（文言）の2テーブルとしています。MVPではYAML配列で管理し、その後DB移行を行うことで段階的に成長可能な設計です。 

## MVPで実装する予定の機能 - メッセージ表示 - ボタン押下でメッセージ切替（ランダム/次へ） - クリックでコピー ※ 読み上げ・SNS共有はMVP後 

## テーブル詳細
 
### languages 
| カラム | 型 | 説明 | 
|---|---|---| 
| id | bigint / PK | | 
| code | string / limit: 10 / UNIQUE NOT NULL | 言語コード例: ja, en-US | 
| name | string / limit: 50 / NOT NULL | 言語名例: 日本語、English | 
| created_at | datetime | | | updated_at | datetime | | 

### messages 
| カラム | 型 | 説明 | 
|---|---|---| 
| id | bigint / PK | | 
| language_id | bigint / FK -> languages.id / NOT NULL / indexed | 言語紐付け | 
| body | string / limit: 100 / NOT NULL | 表示する文言 | 
| enabled | boolean / default true / NOT NULL | **公開フラグ** | 
| sort_order | integer | 表示順制御 | 
| created_at | datetime | | 
| updated_at | datetime | | 

## ER図セルフチェック 
- [x] 画像でER図を表示 
- [x] テーブル名は複数形 
- [x] カラム型・limitを明記 
- [x] 外部キーを明記 
- [x] リレーションは1対多（多対多なし） 
- [x] STIなし 
- [x] 冗長命名なし 

※ 本ER図はMVP後のDB移行を見据えた設計であり、MVP実装時点ではYAMLで運用します。